### PR TITLE
Add validation scripts and test plans

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -41,6 +41,7 @@
       - [x] "/heartbeat off" to turn heartbeat off
       - [x] "/heartbeat on" to turn heartbeat on
 - [~] Implement SMAController Status response
+   - [ ] Report both instantaneous and average muscle current
 - [ ] Come up with auto update method or push via hex file
    - [x] Can we open repo to the public? - Yes
    - [ ] Create Simple Update Process and Automatic Updating Script

--- a/docs/plans/muscle_cooldown_curve_test_plan.md
+++ b/docs/plans/muscle_cooldown_curve_test_plan.md
@@ -1,0 +1,30 @@
+# Muscle Cooldown Curve Test Plan
+
+This experiment measures the natural cooling profile of a ThermoFlex dual–coil Nitinol actuator at room temperature (25 °C). Understanding the passive cooldown time is important for estimating cycle rates and designing closed‑loop control.
+
+## Setup
+
+1. Mount the ThermoFlex muscle under no load.
+2. Connect the actuator to a Node controller powered by a battery or benchtop supply.
+3. Attach temperature sensors (thermocouples or IR camera) to monitor wire temperature.
+4. Ensure ambient room temperature is held near 25 °C with minimal airflow.
+
+## Procedure
+
+1. Heat the muscle to a fully contracted state using a constant current setpoint.
+2. Disable power and begin logging temperature vs time at 50 ms intervals until the wire returns to ambient temperature.
+3. Repeat the test for several cycles to ensure repeatability.
+4. Record ambient temperature throughout the experiment.
+
+## Data Logging
+
+Use the `current_pulse.py` script to apply the heating pulse while simultaneously capturing current feedback. Temperature data can be logged using a separate data acquisition system. Store both datasets in a common CSV for analysis.
+
+## Analysis
+
+- Plot temperature vs time for each trial to generate the cooldown curve.
+- Fit an exponential decay model to estimate the thermal time constant.
+- Compare curves across samples to assess consistency.
+
+This cooldown profile informs actuator modeling and sets expectations for how quickly the muscle can be cycled in typical applications.
+

--- a/docs/plans/sensor_validation_plan.md
+++ b/docs/plans/sensor_validation_plan.md
@@ -1,0 +1,37 @@
+# Sensor Validation Plan
+
+This document describes the procedure for validating voltage and current readouts across multiple ThermoFlex Nodes. The goal is to ensure that every controller reports consistent sensor values so that global voltage and current limits can be applied safely.
+
+## Objectives
+
+1. Verify that supply voltage measurements are consistent across Nodes.
+2. Measure no-load current draw of each Node for comparison.
+3. Compare current pulse responses between Nodes to check for calibration issues.
+
+## Test Scripts
+
+Three Python scripts located in `test/node_validation` implement these checks using the [ThermoFlex Python API](https://github.com/Delta-Robotics-Inc/ThermoFlex-Python-API):
+
+| Script | Purpose |
+|-------|---------|
+| `read_voltage.py` | Logs supply voltage for all detected Nodes over a user defined time interval. |
+| `no_load_current.py` | Measures the idle current of each muscle port with no load attached. |
+| `current_pulse.py` | Applies a configurable current setpoint and records the resulting current curve. |
+
+Each script outputs a CSV file with time stamps, Node ID and measured values. The CSVs can be imported into Excel for further analysis or plotting.
+
+### Example Usage
+
+```bash
+python read_voltage.py --duration 10 --outfile voltages.csv
+python no_load_current.py --duration 10 --outfile idle_current.csv
+python current_pulse.py --target 2.5 --pulse 1.0 --duration 5 --outfile pulse.csv
+```
+
+## Data Analysis
+
+1. Import the CSV results from multiple devices into a spreadsheet.
+2. Plot the recorded curves with separate colors for each Node.
+3. Compare voltage and current readings to identify any offsets or discrepancies.
+4. If readings match across devices, production firmware can enforce global limits; otherwise a calibration step is required for each Node.
+

--- a/example/bare_bones_mosfet_control/bare_bones_mosfet_control.ino
+++ b/example/bare_bones_mosfet_control/bare_bones_mosfet_control.ino
@@ -1,0 +1,47 @@
+/*===========================================================================
+* A simple script to drive the Node Controller mosfets
+* This is a starting point if you want to write your own simple code.alignas
+* If you want to add more features, check out `src/config-shield.hpp` in this repo for pin mappings
+* Instructions: 
+* - Select "Arduino Uno R4 Minima" in boards menu (tools/boards)
+*   - Add through "boards manager" if you don't have it
+* - Set the mosfet speeds in the variables below
+* - Plug muscle or load into M1 or M2 port on the Node Controller
+* - Press the button on the top of the controller to activate! (button close to usb)
+*============================================================================*/
+
+// These mosfets can each be driven up to 60 A
+const int mosfet1 = 9;  // M1 output pin
+const int mosfet2 = 6;  // M2 output pin
+
+const int button = 7;  // Button input pin
+
+int mosfet1_speed = 256;  // Full power on. 0=0%, 256=100%
+int mosfet2_speed = 237;  // 50% power
+
+void setup() {
+  // put your setup code here, to run once:
+
+  pinMode(mosfet1, OUTPUT);
+  pinMode(mosfet2, OUTPUT);
+
+  pinMode(button, INPUT_PULLUP);
+
+  // Start with muscles at 0 power
+  analogWrite(mosfet1, 0);
+  analogWrite(mosfet2, 0);
+}
+
+// Runs repeatedly (forever)
+void loop() {
+
+  // If button is pressed, set the mosfet speeds (button logic is flipped)
+  if(!digitalRead(button)) {
+    analogWrite(mosfet1, mosfet1_speed);  // Change the speed at the top (or in code)
+    analogWrite(mosfet2, mosfet2_speed);
+  }
+  else {
+    analogWrite(mosfet1, 0);  // Turn off if button is not pressed
+    analogWrite(mosfet2, 0);
+  }
+}

--- a/src/config-shield-v1.0.hpp
+++ b/src/config-shield-v1.0.hpp
@@ -40,18 +40,18 @@ const float AMP_GAIN = 100.0f;  // [V/V] Vin/Vout gain of amplifier
 #define STATUS_RGB_BLUE 11
 
 //SMAController0
-#define M1_MOS_TRIG 9
-#define M1_CURR_RD A0
-#define M1_VLD_RD A2
-#define M1_ALERT 2
+#define M1_MOS_TRIG 9   // PWM pin for MOSFET driver
+#define M1_CURR_RD A0   // Current sense amplifier
+#define M1_VLD_RD A2    // Voltage divider
+#define M1_ALERT 2      // Alert pin
 
 //SMAController1
-#define M2_MOS_TRIG 6
-#define M2_CURR_RD A1
-#define M2_VLD_RD A3
-#define M2_ALERT 3
+#define M2_MOS_TRIG 6   // PWM pin for MOSFET driver
+#define M2_CURR_RD A1   // Current sense amplifier
+#define M2_VLD_RD A3    // Voltage divider
+#define M2_ALERT 3      // Alert pin
 
-#define AUX_BUTTON 7
+#define AUX_BUTTON 7    // Button input pin, active low with pullup resistor
 #define MANUAL_MODE_POT A5
 const float MANUAL_MODE_THRESHOLD = 0.02f;
 

--- a/test/node_validation/current_pulse.py
+++ b/test/node_validation/current_pulse.py
@@ -1,0 +1,58 @@
+import argparse
+import csv
+import time
+import thermoflex as tf
+
+
+def run_current_pulse(nodes, target_amp, pulse_time=2.0, duration=10.0, interval=0.1, outfile='current_pulse.csv'):
+    start = time.time()
+    with open(outfile, 'w', newline='') as csvfile:
+        writer = csv.writer(csvfile)
+        writer.writerow(['timestamp', 'node_id', 'muscle', 'load_amps'])
+
+        # Configure muscles
+        for net in nodes:
+            for node in net.node_list:
+                for musc in node.muscles.values():
+                    node.setMode('amps', f'm{musc.idnum+1}')
+                    node.setSetpoint(tf.command_t.modedef.index('amps'), f'm{musc.idnum+1}', target_amp)
+                    node.enable(musc)
+
+        while time.time() - start < duration:
+            tf.update()
+            for net in tf.controls.NodeNet.netlist:
+                for node in net.node_list:
+                    node.status('compact')
+                    for key, muscle in node.muscles.items():
+                        amps = muscle.SMA_status['load_amps'][0] if muscle.SMA_status['load_amps'] else None
+                        writer.writerow([time.time(), ''.join(f'{b:02X}' for b in node.node_id), key, amps])
+            if time.time() - start > pulse_time:
+                for net in nodes:
+                    for node in net.node_list:
+                        node.disableAll()
+            time.sleep(interval)
+
+        for net in nodes:
+            for node in net.node_list:
+                node.disableAll()
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Run a current pulse through the muscle')
+    parser.add_argument('--target', type=float, required=True, help='target current in amps')
+    parser.add_argument('--pulse', type=float, default=2.0, help='pulse time in seconds')
+    parser.add_argument('--duration', type=float, default=10.0)
+    parser.add_argument('--interval', type=float, default=0.1)
+    parser.add_argument('--outfile', default='current_pulse.csv')
+    args = parser.parse_args()
+
+    nets = tf.discover([105])
+    for net in nets:
+        net.refreshDevices()
+
+    run_current_pulse(nets, args.target, args.pulse, args.duration, args.interval, args.outfile)
+    tf.endAll()
+
+
+if __name__ == '__main__':
+    main()

--- a/test/node_validation/no_load_current.py
+++ b/test/node_validation/no_load_current.py
@@ -1,0 +1,40 @@
+import argparse
+import csv
+import time
+import thermoflex as tf
+
+
+def sample_current(nodes, duration=10, interval=0.1, outfile='no_load_current.csv'):
+    start = time.time()
+    with open(outfile, 'w', newline='') as csvfile:
+        writer = csv.writer(csvfile)
+        header = ['timestamp', 'node_id', 'muscle', 'load_amps']
+        writer.writerow(header)
+        while time.time() - start < duration:
+            tf.update()
+            for net in tf.controls.NodeNet.netlist:
+                for node in net.node_list:
+                    for key, muscle in node.muscles.items():
+                        node.status('compact')
+                        amps = muscle.SMA_status['load_amps'][0] if muscle.SMA_status['load_amps'] else None
+                        writer.writerow([time.time(), ''.join(f'{b:02X}' for b in node.node_id), key, amps])
+            time.sleep(interval)
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Measure no-load current')
+    parser.add_argument('--duration', type=float, default=10.0)
+    parser.add_argument('--interval', type=float, default=0.1)
+    parser.add_argument('--outfile', default='no_load_current.csv')
+    args = parser.parse_args()
+
+    nets = tf.discover([105])
+    for net in nets:
+        net.refreshDevices()
+
+    sample_current(nets, args.duration, args.interval, args.outfile)
+    tf.endAll()
+
+
+if __name__ == '__main__':
+    main()

--- a/test/node_validation/read_voltage.py
+++ b/test/node_validation/read_voltage.py
@@ -4,19 +4,17 @@ import time
 import thermoflex as tf
 
 
-def sample_voltage(nodes, duration=10, interval=0.1, out_file='voltage_readings.csv'):
+def sample_voltage(nodes, duration=10.0, interval=0.1, out_file="voltage_readings.csv"):
     start = time.time()
-    with open(out_file, 'w', newline='') as csvfile:
+    with open(out_file, "w", newline="") as csvfile:
         writer = csv.writer(csvfile)
-        header = ['timestamp', 'node_id', 'supply_voltage']
-        writer.writerow(header)
+        writer.writerow(["timestamp", "node_id", "supply_voltage"])
         while time.time() - start < duration:
-            tf.update()  # run network background tasks
-            for net in tf.controls.NodeNet.netlist:
-                for node in net.node_list:
-                    node.status('compact')
-                    status = node.node_status.get('volt_supply')
-                    writer.writerow([time.time(), ''.join(f'{b:02X}' for b in node.node_id), status])
+            for node in nodes:
+                node.status("compact")
+                v = node.node_status.get("volt_supply")
+                nid = ".".join(str(b) for b in node.id)
+                writer.writerow([time.time(), nid, v])
             time.sleep(interval)
 
 
@@ -31,7 +29,8 @@ def main():
     for net in nets:
         net.refreshDevices()
 
-    sample_voltage(nets, args.duration, args.interval, args.outfile)
+    node_list = [node for net in nets for node in net.node_list]
+    sample_voltage(node_list, args.duration, args.interval, args.outfile)
     tf.endAll()
 
 

--- a/test/node_validation/read_voltage.py
+++ b/test/node_validation/read_voltage.py
@@ -1,0 +1,39 @@
+import argparse
+import csv
+import time
+import thermoflex as tf
+
+
+def sample_voltage(nodes, duration=10, interval=0.1, out_file='voltage_readings.csv'):
+    start = time.time()
+    with open(out_file, 'w', newline='') as csvfile:
+        writer = csv.writer(csvfile)
+        header = ['timestamp', 'node_id', 'supply_voltage']
+        writer.writerow(header)
+        while time.time() - start < duration:
+            tf.update()  # run network background tasks
+            for net in tf.controls.NodeNet.netlist:
+                for node in net.node_list:
+                    node.status('compact')
+                    status = node.node_status.get('volt_supply')
+                    writer.writerow([time.time(), ''.join(f'{b:02X}' for b in node.node_id), status])
+            time.sleep(interval)
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Log node supply voltage over time')
+    parser.add_argument('--duration', type=float, default=10.0, help='logging duration in seconds')
+    parser.add_argument('--interval', type=float, default=0.1, help='sample interval in seconds')
+    parser.add_argument('--outfile', default='voltage_readings.csv', help='CSV output file')
+    args = parser.parse_args()
+
+    nets = tf.discover([105])
+    for net in nets:
+        net.refreshDevices()
+
+    sample_voltage(nets, args.duration, args.interval, args.outfile)
+    tf.endAll()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add Python scripts for node voltage/current validation
- include sensor validation and cooldown curve test plans
- compile test for CurrentController

## Testing
- `g++ -std=c++17 test/test_current_controller.cpp src/drivers/CurrentController.cpp src/drivers/MiniPID.cpp -I src -o test_current_controller && ./test_current_controller`
- `python -m py_compile test/node_validation/*.py`


------
https://chatgpt.com/codex/tasks/task_e_684b569b495883239495d5ef7db3f7f8